### PR TITLE
Apply patches that were added in 224236b

### DIFF
--- a/.build.yml
+++ b/.build.yml
@@ -15,7 +15,7 @@ packages:
 sources:
   - https://git.sr.ht/~elagost/signal-desktop-builder
 environment:
-  VERSION: "6.29.1"
+  VERSION: "6.29.1+p1"
 secrets:
   - 07d27e19-a690-46d1-9f0a-4d391f5968b8
   - 07e0c486-ee68-4149-a12e-fa082897aefc

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
       - name: build deb
         shell: bash
         env:
-          VERSION: "6.29.1"
+          VERSION: "6.29.1+p1"
         run: |
           set -x
           echo "Version is: $VERSION"
@@ -43,7 +43,7 @@ jobs:
           cp ~/signal-desktop.deb .
       - name: upload .deb as build artifact 
         env:
-          VERSION: "6.29.1"
+          VERSION: "6.29.1+p1"
         uses: actions/upload-artifact@v3
         with:
           name: signal-desktop-arm64-${{ env.VERSION }}.deb
@@ -67,7 +67,7 @@ jobs:
           rsync -azu --delete /opt/pakrepo/ server:/var/www/htdocs/elagost.com/flatpak/repo/
       - name: clean up images for self-hosted runner
         env:
-          VERSION: "6.29.1"
+          VERSION: "6.29.1+p1"
         shell: bash
         run: |
           podman container rm signal-desktop-${{ env.VERSION }}

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,7 +5,7 @@
 # other CI build files.
 
 variables:
-  VERSION: "6.29.1"
+  VERSION: "6.29.1+p1"
 
 before_script:
   - shopt -s expand_aliases

--- a/org.signal.Signal.metainfo.xml
+++ b/org.signal.Signal.metainfo.xml
@@ -36,7 +36,7 @@
     </screenshot>
   </screenshots>
   <releases>
-    <release version="6.29.1" date="2023-08-24"/>
+    <release version="6.29.1+p1" date="2023-08-26"/>
   </releases>
   <content_rating type="oars-1.1">
     <content_attribute id="violence-cartoon">none</content_attribute>

--- a/signal-buildscript.sh
+++ b/signal-buildscript.sh
@@ -9,6 +9,7 @@ git-lfs install
 git config --global user.name name
 git config --global user.email name@example.com
 git am ../0001-Remove-stories-icon.patch
+git am ../0001-Minimize-gutter-on-small-screens.patch
 git am ../0001-reinstall-cross-deps-on-non-darwin-platforms.patch
 # The mock tests are broken on custom arm builds
 sed -r '/mock/d' -i package.json

--- a/signal-buildscript.sh
+++ b/signal-buildscript.sh
@@ -11,6 +11,7 @@ git config --global user.email name@example.com
 git am ../0001-Remove-stories-icon.patch
 git am ../0001-Minimize-gutter-on-small-screens.patch
 git am ../0001-reinstall-cross-deps-on-non-darwin-platforms.patch
+git am ../0001-Always-return-MIN_WIDTH-from-storage.patch
 # The mock tests are broken on custom arm builds
 sed -r '/mock/d' -i package.json
 # Drop "--no-sandbox" commit from build


### PR DESCRIPTION
This PR applies the following two patches:

- `0001-Always-return-MIN_WIDTH-from-storage.patch`
- `0001-Minimize-gutter-on-small-screens.patch`

Those two patch files were added and modified in 224236b but never applied.

The PR also includes a revision bump (6.29.1+p1) to make sure that the already-published flatpak 6.29.1 is untouched. (The `p1` means patch no. 1.)
I think this scheme should work with the autobuild mechanism.  I expect the autobuilder to undo the `+p1` part once upstream releases the next update.